### PR TITLE
Small correction in trainer.py

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -148,7 +148,7 @@ def _set_device(args):
     gpus = []
 
     for device in device_type:
-        if device_type == -1:
+        if device == -1:
             device = torch.device("cpu")
         else:
             device = torch.device("cuda:{}".format(device))


### PR DESCRIPTION
In trainer.py in the function "_set_device", the comparison to determine whether to use cpu or gpu is done inside the loop with the variable "device_type". If "device_type" is -1, "cpu" would have been added to the list of devices. 

However, if  "device_type" is -1, an error would have been thrown beforehand, since we tried to iterate over -1.

I assume this is a typo, so changing the variable to compare from "device_type" to the local variable "device" will probably have the intended behaviour.