### PR TITLE
fix in group accuracy in ulits/toolkit.py

### DIFF
--- a/utils/toolkit.py
+++ b/utils/toolkit.py
@@ -47,7 +47,7 @@ def accuracy(y_pred, y_true, nb_old, increment=10):
     )
 
     # Grouped accuracy
-    for class_id in range(0, np.max(y_true), increment):
+    for class_id in range(0, np.max(y_true)+1, increment):
         idxes = np.where(
             np.logical_and(y_true >= class_id, y_true < class_id + increment)
         )[0]


### PR DESCRIPTION
when calculating group accuracy in ./ulits/toolkit.py file, the accuracy for the last group in each task is calculated incorrectly.

For example CIFAR100, which has classes [0, 1, 2, ..., 99] and Base 0 Increment 10 case,  the issue arises when the code attempts to compute the accuracy for each task.
In the first task with a base of 0 and an increment of 10, the code only calculates the accuracy for the first 9 classes ([0, 1, 2, ..., 8]), while it should be calculating the accuracy for all 10 classes ([0, 1, 2, ..., 9]).
In subsequent tasks, for example, task 2 with 20 classes ([0, 1, 2, ..., 19]), the code correctly computes the accuracy for the first 10 classes (task 1) but then inaccurately computes the accuracy for task 2 by only considering classes from 10 to 18, missing the last class (19).
similarly happens for all the tasks